### PR TITLE
Fix intermediate image reference in Dockerfile in ci blog post

### DIFF
--- a/content/posts/rust-continuous-delivery.md
+++ b/content/posts/rust-continuous-delivery.md
@@ -86,7 +86,7 @@ RUN cargo build --release
 
 # Build Run
 FROM debian:stable-slim AS run
-COPY --from=builder /build/app/target/release/app app
+COPY --from=build /build/app/target/release/app app
 ENTRYPOINT ["./app"]
 ```
 


### PR DESCRIPTION
Thx for the post. I think you did a renaming and this one was not renamed